### PR TITLE
Idea to fix mac arm64 brew issue with dynamic library not found

### DIFF
--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 import * as exec from '@actions/exec';
 import {ExecOptions} from '@actions/exec/lib/interfaces';
-import {IS_WINDOWS, IS_LINUX} from './utils';
+import {IS_WINDOWS, IS_LINUX, IS_MAC, getMacOSBrewPath} from './utils';
 
 const TOKEN = core.getInput('token');
 const AUTH = !TOKEN ? undefined : `token ${TOKEN}`;
@@ -44,12 +44,13 @@ export function getManifest(): Promise<tc.IToolRelease[]> {
 }
 
 async function installPython(workingDirectory: string) {
+  const brewPath = await getMacOSBrewPath();
   const options: ExecOptions = {
     cwd: workingDirectory,
     env: {
       ...process.env,
       ...(IS_LINUX && {LD_LIBRARY_PATH: path.join(workingDirectory, 'lib')})
-      ...(IS_MAC && {LD_LIBRARY_PATH: path.join('$(brew --prefix)', 'lib')})
+      ...(IS_MAC && {LD_LIBRARY_PATH: path.join(brewPath, 'lib')})
     },
     silent: true,
     listeners: {

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -49,6 +49,7 @@ async function installPython(workingDirectory: string) {
     env: {
       ...process.env,
       ...(IS_LINUX && {LD_LIBRARY_PATH: path.join(workingDirectory, 'lib')})
+      ...(IS_MAC && {LD_LIBRARY_PATH: path.join('$(brew --prefix)', 'lib')})
     },
     silent: true,
     listeners: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -152,6 +152,16 @@ async function getMacOSInfo() {
   return {osName: 'macOS', osVersion: macOSVersion};
 }
 
+export async function getMacOSBrewPath() {
+  const {stdout} = await exec.getExecOutput('brew', ['--prefix'], {
+    silent: true
+  });
+
+  const brewPath = stdout.trim();
+
+  return {brewPath: brewPath};
+}
+
 export async function getLinuxInfo() {
   const {stdout} = await exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
     silent: true


### PR DESCRIPTION
**Description:**
Attempt to fix issue detected on new arm64 macos runners we are testing against.

Location of the missing library on the runner:
```
maccloud@macclouds-Mac-mini-160 ~ % anka run finaroux-setup-python locate libintl.8.dylib
/opt/homebrew/Cellar/gettext/0.21.1/lib/libintl.8.dylib
/opt/homebrew/lib/libintl.8.dylib
```

Error message:
```
Run actions/setup-python@v4
  with:
    python-version: 3.10
    check-latest: false
    token: ***
    update-environment: true
  env:
    PYTHON_VERSION: 3.10
    FLAKY_TESTS: keep_retrying
Installed versions
  Version 3.10 was not found in the local cache
  Version 3.10 is available for downloading
  Download from "https://github.com/actions/python-versions/releases/download/3.10.11-46[2](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:2)66465[3](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:3)5/python-3.10.11-darwin-x6[4](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:4).tar.gz"
  Extract downloaded archive
  /usr/bin/tar xz -C /Users/runner/work/_temp/027[5](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:5)2f[6](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:6)8-439d-4efe-a603-0c601[7](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:7)b20333 -f /Users/runner/work/_temp/cd355a7f-b457-4b64-91f5-1b06fa9007b7
  Execute installation script
  Check if Python hostedtoolcache folder exist...
  Creating Python hostedtoolcache folder...
  Create Python 3.10.11 folder
  Copy Python binaries to hostedtoolcache folder
  Create additional symlinks (Required for the UsePythonVersion Azure Pipelines task and the setup-python GitHub Action)
  Upgrading pip...
  Error: dyld[31159]: Library not loaded: /usr/local/opt/gettext/lib/libintl.[8](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:8).dylib
    Referenced from: <[9](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:9)F60F915-FF24-3FD6-95A4-F909D3E265AA> /Users/runner/hostedtoolcache/Python/3.[10](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:11).[11](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:12)/x64/bin/python3.10
    Reason: tried: '/usr/local/opt/gettext/lib/libintl.8.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/gettext/lib/libintl.8.dylib' (no such file), '/usr/local/opt/gettext/lib/libintl.8.dylib' (no such fi
  Error: le), '/usr/local/lib/libintl.8.dylib' (no such file), '/usr/lib/libintl.8.dylib' (no such file, not in dyld cache)
  ./setup.sh: line 52: 31[15](https://github.com/hosted-runners-perf/node-private/actions/runs/4726972495/jobs/8387071813#step:3:16)9 Abort trap: 6           ./python -m ensurepip
```

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.